### PR TITLE
Run tests using the eBPF probe

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,4 +1,4 @@
-FROM fedora:35
+FROM fedora:36
 
 RUN dnf install -y \
     gcc \

--- a/Dockerfile.sinsp
+++ b/Dockerfile.sinsp
@@ -5,9 +5,9 @@ COPY /libs /libs
 # Build falcosecurity/libs
 RUN rm -rf /libs/build && mkdir /libs/build && \
     cmake -DUSE_BUNDLED_DEPS=OFF -S /libs -B /libs/build && \
-    make -C /libs/build/libsinsp/examples sinsp-example
+    make -j"$(nproc)" -C /libs/build/libsinsp/examples sinsp-example
 
-FROM fedora:35 as runner
+FROM fedora:36 as runner
 
 RUN dnf install -y \
     libcurl \
@@ -20,5 +20,6 @@ RUN dnf install -y \
     tbb
 
 COPY --from=builder /libs/build/libsinsp/examples/sinsp-example /usr/local/bin/sinsp-example
+COPY /tests/driver/probe.o /driver/probe.o
 
 ENTRYPOINT [ "sinsp-example" ]

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ builder:
 	docker build --tag libs-it-builder:latest \
 		-f Dockerfile.builder .
 
-scap.ko: builder
+drivers: builder
 	docker run --rm --name kernel-builder \
 		-v $(CURDIR)/libs:/libs \
 		-v /usr/include/bpf:/usr/include/bpf:ro \
@@ -14,19 +14,21 @@ scap.ko: builder
 		-v /usr/src/:/usr/src/:ro \
 		libs-it-builder:latest "cmake -S /libs \
 		-DUSE_BUNDLED_DEPS=OFF \
+		-DBUILD_BPF=ON \
 		-B /libs/build && \
 		make -C /libs/build/driver"
-	@mkdir -p $(CURDIR)/tests/driver/scap.ko
+	@mkdir -p $(CURDIR)/tests/driver/
 	cp $(CURDIR)/libs/build/driver/src/scap.ko $(CURDIR)/tests/driver/scap.ko
+	cp $(CURDIR)/libs/build/driver/bpf/probe.o $(CURDIR)/tests/driver/probe.o
 	rm -rf $(CURDIR)/libs/build/
 
 .PHONY: userspace
-userspace: builder
+userspace: builder drivers
 	docker build --tag sinsp-example:latest \
 		-f Dockerfile.sinsp .
 
 .PHONY: tests
-tests: userspace scap.ko
+tests: userspace
 	make -C tests
 
 .PHONY: clean
@@ -35,4 +37,4 @@ clean:
 		sinsp-example:latest \
 		falco-test-runner:latest
 	rm -rf $(CURDIR)/libs/build
-	rm -f $(CURDIR)/tests/driver/scap.ko
+	rm -rf $(CURDIR)/tests/driver/

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:35
+FROM fedora:36
 
 WORKDIR /tests
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -5,13 +5,28 @@ all: run-tests
 build-tester:
 	docker build --tag falco-test-runner:latest .
 
-.PHONY: run-tests
-run-tests: build-tester
-	@mkdir -p $(CURDIR)/report
+.PHONY: kmod-tests
+kmod-tests: build-tester
+	@mkdir -p $(CURDIR)/report/kmod
 	docker run --rm \
 		--privileged \
 		--name falco-tester \
 		-v /dev:/dev:ro \
 		-v /var/run/docker.sock:/var/run/docker.sock \
-		-v $(CURDIR)/report:/report \
+		-v $(CURDIR)/report/kmod:/report \
 		falco-test-runner:latest
+
+.PHONY: ebpf-tests
+ebpf-tests: build-tester
+	@mkdir -p $(CURDIR)/report/ebpf
+	docker run --rm \
+		--privileged \
+		--name falco-tester \
+		-e BPF_PROBE=/driver/probe.o \
+		-v /dev:/dev:ro \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-v $(CURDIR)/report/ebpf:/report \
+		falco-test-runner:latest
+
+.PHONY: run-tests
+run-tests: kmod-tests ebpf-tests

--- a/tests/commons/sinspqa/sinsp.py
+++ b/tests/commons/sinspqa/sinsp.py
@@ -1,7 +1,6 @@
-import docker
 from datetime import datetime
 from time import sleep
-import json
+import os
 
 
 class SinspStreamer:
@@ -118,3 +117,13 @@ def assert_events(expected_events, container):
                 success = True
                 break
         assert success, f"Did not receive expected event: {event}"
+
+
+def is_ebpf():
+    """
+    Checks if the tests are being run with eBPF.
+
+    Returns:
+        True if the test is running with the eBPF driver, False otherwise.
+    """
+    return "BPF_PROBE" in os.environ

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,11 @@ def load_module():
     """
     Loads and unloads the scap.ko module to be used by the integration tests.
     """
+    if "BPF_PROBE" in os.environ:
+        # Runnning with the ebpf probe
+        yield
+        return
+
     subprocess.run(args=["insmod", "/driver/scap.ko"]).check_returncode()
     yield
     subprocess.run(["rmmod", "scap"]).check_returncode()
@@ -43,13 +48,19 @@ def sinsp(request, docker_client):
                            consistency="delegated", read_only=True)
     ]
 
+    environment = {}
+
+    if "BPF_PROBE" in os.environ:
+        environment["BPF_PROBE"] = os.environ.get("BPF_PROBE")
+
     print(request.param)
 
     sinsp = docker_client.containers.run("sinsp-example:latest",
                                          request.param,
                                          detach=True,
                                          privileged=True,
-                                         mounts=mounts)
+                                         mounts=mounts,
+                                         environment=environment)
     sleep(1)  # Wait for sinsp to start capturing
     yield sinsp
     sinsp.stop()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import docker
 import os
 from time import sleep
 from sinspqa import SINSP_LOG_PATH
+from sinspqa.sinsp import is_ebpf
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -11,7 +12,7 @@ def load_module():
     """
     Loads and unloads the scap.ko module to be used by the integration tests.
     """
-    if "BPF_PROBE" in os.environ:
+    if is_ebpf():
         # Runnning with the ebpf probe
         yield
         return
@@ -50,7 +51,7 @@ def sinsp(request, docker_client):
 
     environment = {}
 
-    if "BPF_PROBE" in os.environ:
+    if is_ebpf():
         environment["BPF_PROBE"] = os.environ.get("BPF_PROBE")
 
     print(request.param)

--- a/tests/test_process/test_process.py
+++ b/tests/test_process/test_process.py
@@ -1,11 +1,12 @@
 import pytest
 import subprocess
-from sinspqa.sinsp import assert_events
+from sinspqa.sinsp import assert_events, is_ebpf
 
 
 sinsp_filters = [
     ["-f", "evt.category=process and evt.type=execve"]
 ]
+
 
 @pytest.mark.parametrize("sinsp", sinsp_filters, indirect=True)
 def test_process(sinsp):
@@ -22,13 +23,13 @@ def test_process(sinsp):
             'cat': 'PROCESS',
             'type': 'execve',
             'exe': '/usr/bin/cat',
-            'cmd': 'cat /tmp/test.txt'
+            'cmd': 'cat /tmp/test.txt' if not is_ebpf() else "cat"
         }, {
             'is_host': False,
             'cat': 'PROCESS',
             'type': 'execve',
             'exe': '/usr/bin/rm',
-            'cmd': 'rm -f /tmp/test.txt'
+            'cmd': 'rm -f /tmp/test.txt' if not is_ebpf() else "rm"
         }
     ]
 


### PR DESCRIPTION
Runs the existing tests using the eBPF probe instead of the kernel module.

This is achieved by embedding the eBPF probe in the `sinsp-example` image in a know location and later setting the `BPF_PROBE` environment variable when running it.