### PR TITLE
Run tests on Github actions

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -17,3 +17,10 @@ jobs:
 
     - name: Build and test Falco/libs
       run: make tests
+
+    - name: Archive test reports
+      uses: actions/upload-artifact@v3
+      with:
+        name: test-reports
+        path: |
+          tests/reports/

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -25,7 +25,7 @@ jobs:
       uses: addnab/docker-run-action@v3
       with:
         image: libs-it-builder:latest
-        options: -v {{ github.workspace }}/libs:/libs -v /usr/include/bpf:/usr/include/bpf:ro -v /lib/modules/:/lib/modules/:ro -v /usr/src/:/usr/src/:ro
+        options: -v ${{ github.workspace }}/libs:/libs -v /usr/include/bpf:/usr/include/bpf:ro -v /lib/modules/:/lib/modules/:ro -v /usr/src/:/usr/src/:ro
         run: |
           cmake -S /libs \
             -DUSE_BUNDLED_DEPS=OFF \

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -22,7 +22,16 @@ jobs:
       run: make builder
 
     - name: Build drivers
-      run: make drivers
+      uses: addnab/docker-run-action@v3
+      with:
+        image: libs-it-builder:latest
+        options: -v $GITHUB_WORKSPACE/libs:/libs -v /usr/include/bpf:/usr/include/bpf:ro -v /lib/modules/:/lib/modules/:ro -v /usr/src/:/usr/src/:ro
+        run: |
+          cmake -S /libs \
+            -DUSE_BUNDLED_DEPS=OFF \
+            -DBUILD_BPF=ON \
+            -B /libs/build
+          make -C /libs/build/driver
 
     - name: Build userspace
       run: make userspace

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -20,6 +20,7 @@ jobs:
 
     - name: Archive test reports
       uses: actions/upload-artifact@v3
+      if: always()
       with:
         name: test-reports
         path: |

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [ "master" ]
 
 jobs:
-  build:
+  build-and-test:
     runs-on: ubuntu-latest
 
     steps:
@@ -15,16 +15,5 @@ jobs:
       with:
         submodules: true
 
-    - name: Install kernel headers
-      run: |
-        sudo apt update
-        sudo apt install -y linux-headers-$(uname -r)
-
-    - name: Build builder image
-      run: make builder
-
-    - name: Build drivers
-      run: make drivers
-
-    - name: Build userspace
-      run: make userspace
+    - name: Build and test Falco/libs
+      run: make tests

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -12,6 +12,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        submodules: true
 
     - name: Install kernel headers
       run: |
@@ -22,16 +24,7 @@ jobs:
       run: make builder
 
     - name: Build drivers
-      uses: addnab/docker-run-action@v3
-      with:
-        image: libs-it-builder:latest
-        options: -v ${{ github.workspace }}/libs:/libs -v /usr/include/bpf:/usr/include/bpf:ro -v /lib/modules/:/lib/modules/:ro -v /usr/src/:/usr/src/:ro
-        run: |
-          cmake -S /libs \
-            -DUSE_BUNDLED_DEPS=OFF \
-            -DBUILD_BPF=ON \
-            -B /libs/build
-          make -C /libs/build/driver
+      run: make drivers
 
     - name: Build userspace
       run: make userspace

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -24,4 +24,4 @@ jobs:
       with:
         name: test-reports
         path: |
-          tests/reports/
+          tests/report/

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -13,5 +13,16 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Install kernel headers
+      run: |
+        sudo apt update
+        sudo apt install -y linux-headers-$(uname -r)
+
     - name: Build builder image
       run: make builder
+
+    - name: Build drivers
+      run: make drivers
+
+    - name: Build userspace
+      run: make userspace

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -25,7 +25,7 @@ jobs:
       uses: addnab/docker-run-action@v3
       with:
         image: libs-it-builder:latest
-        options: -v $GITHUB_WORKSPACE/libs:/libs -v /usr/include/bpf:/usr/include/bpf:ro -v /lib/modules/:/lib/modules/:ro -v /usr/src/:/usr/src/:ro
+        options: -v {{ github.workspace }}/libs:/libs -v /usr/include/bpf:/usr/include/bpf:ro -v /lib/modules/:/lib/modules/:ro -v /usr/src/:/usr/src/:ro
         run: |
           cmake -S /libs \
             -DUSE_BUNDLED_DEPS=OFF \

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -1,0 +1,17 @@
+name: Falco libs QA
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Build builder image
+      run: make builder

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ drivers: builder
 		-v /usr/include/bpf:/usr/include/bpf:ro \
 		-v /lib/modules/:/lib/modules/:ro \
 		-v /usr/src/:/usr/src/:ro \
+		--user $(shell id -u):$(shell id -g) \
 		libs-it-builder:latest "cmake -S /libs \
 		-DUSE_BUNDLED_DEPS=OFF \
 		-DBUILD_BPF=ON \


### PR DESCRIPTION
Build and run the test containers in Github actions.

The `--user` argument was added to the driver build so that the created artifacts are not stored as root.