### PR TITLE
Temporarily disable eBPF tests

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -16,7 +16,9 @@ jobs:
         submodules: true
 
     - name: Build and test Falco/libs
-      run: PARALLEL_BUILDS="$(nproc)" make tests
+      run: |
+        PARALLEL_BUILDS="$(nproc)" make userspace
+        make -C tests kmod-tests
 
     - name: Archive test reports
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
The eBPF tests have a minot memory leak that causes them to fail. I'm disabling them from GHA until falcosecurity/libs#427 is merged.