### PR TITLE
Fix missing valijson

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ drivers: builder
 		--user $(shell id -u):$(shell id -g) \
 		quay.io/mmoltras/falco-libs-builder:$(TAG) "cmake -S /libs \
 			-DUSE_BUNDLED_DEPS=OFF \
+			-DUSE_BUNDLED_VALIJSON=ON \
 			-DBUILD_BPF=ON \
 			-B /build/driver-build && \
 			make -j$(PARALLEL_BUILDS) -C /build/driver-build/driver"


### PR DESCRIPTION
Need to explicitly ask for the bundled valijson on latest libs (unused for the moment).